### PR TITLE
Specifying memcache bin

### DIFF
--- a/car_reference.tokens.inc
+++ b/car_reference.tokens.inc
@@ -74,7 +74,7 @@ function car_reference_fields() {
 
   // Use the memcache.
   $cid = __FUNCTION__;
-  if ($cache = cache_get($cid)) {
+  if ($cache = cache_get($cid, 'cache')) {
     $fields = $cache->data;
     return $fields;
   }
@@ -83,7 +83,7 @@ function car_reference_fields() {
   $fields = field_read_fields(array('type' => 'car_reference'));
 
   // Cache it.
-  cache_set($cid, $fields, CACHE_TEMPORARY);
+  cache_set($cid, $fields, 'cache', CACHE_TEMPORARY);
 
   return $fields;
 }


### PR DESCRIPTION
Noticed that we were setting the cache bin to `CACHE_TEMPORARY` as we missed the `$bin` argument. This means we are missing the memcache entry and running the `field_config` query once per page.

The static cache alone has drastically reduced the number of `field_config` queries, but we should fix this.